### PR TITLE
Add default print to stdout for mwetable/mwearray

### DIFF
--- a/src/ClipData.jl
+++ b/src/ClipData.jl
@@ -160,14 +160,15 @@ function cliparray(t::AbstractVecOrMat; returnstring = false, delim='\t',
 end
 
 """
-    mwetable(; name="df")
+    mwetable([io::IO=stdout]; name="df")
 
 Create a Minimum Working Example (MWE) using
 the clipboard. `tablmwe` prints out a multi-line
 comma-separated string and provides the necessary
 code to read that string using `CSV.File`.
 The object is assigned the name given by
-`name` (default `"df"`).
+`name` (default `"df"`). Prints to `io`,
+which is by default `stdout`.
 
 # Examples
 
@@ -187,10 +188,13 @@ a,b
 ```
 
 """
-function mwetable(; returnstring=false, name="df")
+function mwetable(io::IO; returnstring=false, name="df")
     t = cliptable()
-    mwetable(t, returnstring=returnstring, name=name)
+    mwetable(io, t, returnstring=returnstring, name=name)
 end
+
+mwetable(; kwargs...) = mwetable(stdout; kwargs...)
+
 
 """
     mwetable([io::IO=stdout], t; name="df")
@@ -201,7 +205,8 @@ an existing Tables.jl-compatible object.
 comma-separated string and provides the necessary
 code to read that string using `CSV.File`.
 The object is assigned the name given by
-`name` (default `:df`).
+`name` (default `:df`). Prints to `io`,
+which is by default `stdout`.
 
 # Examples
 
@@ -259,7 +264,8 @@ an existing Tables.jl-compatible object.
 comma-separated string and provides the necessary
 code to read that string using `CSV.File`. The name
 assigned to the object in the MWE is the
-same as the name of the input object.
+same as the name of the input object. Prints
+to `stdout`.
 
 # Examples
 
@@ -281,13 +287,14 @@ macro mwetable(t)
 end
 
 """
-    mwearray(; name=:X)
+    mwearray([io::IO=stdout]; name=:X)
 
 Create a Minimum Working Example (MWE) from
 the clipboard to create an array. `mwearray`
 returns the a multi-line string with the
 code necessary to read the string stored in
-clipboard as a `Vector` or `Matrix`.
+clipboard as a `Vector` or `Matrix`. Prints to `io`,
+which is by default `stdout`.
 
 # Examples
 
@@ -304,11 +311,13 @@ X = \"\"\"
 \"\"\" |> IOBuffer |> CSV.File |> Tables.matrix
 ```
 """
-function mwearray(; returnstring=false, name=nothing)
+function mwearray(io::IO; returnstring=false, name=nothing)
     t = cliparray()
     name= t isa AbstractVector ? :x : :X
-    mwearray(t, returnstring=returnstring, name=name)
+    mwearray(io, t, returnstring=returnstring, name=name)
 end
+
+mwearray(; kwargs...) = mwearray(stdout; kwargs...)
 
 """
     mwearray([io::IO=stdout], t::AbstractMatrix; name=:X)
@@ -316,7 +325,8 @@ end
 Create a Minimum Working Example (MWE) from
 a `Matrix`. `mwearray`
 returns the a multi-line string with the
-code necessary to recreate `t`.
+code necessary to recreate `t`. Prints to `io`,
+which is by default `stdout`.
 
 # Examples
 
@@ -364,7 +374,8 @@ end
 Create a Minimum Working Example (MWE) from
 a `Vector`. `mwearray`
 returns the a multi-line string with the
-code necessary to recreate `t`.
+code necessary to recreate `t`. Prints to `io`,
+which is by default `stdout`.
 
 # Example
 
@@ -417,7 +428,8 @@ end
 
 Create a Minimum Working Example (MWE)
 from a `Vector` or `Matrix` with the same
-name as the object in the Julia session.
+name as the object in the Julia session. Prints
+to `stdout`.
 
 # Examples
 

--- a/src/ClipData.jl
+++ b/src/ClipData.jl
@@ -193,7 +193,7 @@ function mwetable(; returnstring=false, name="df")
 end
 
 """
-    mwetable(t; name="df")
+    mwetable([io::IO=stdout], t; name="df")
 
 Create a Minimum Working Example (MWE) from
 an existing Tables.jl-compatible object.
@@ -218,7 +218,7 @@ a,b
 \"\"\" |> IOBuffer |> CSV.File
 ```
 """
-function mwetable(t; returnstring=false, name="df")
+function mwetable(io::IO, t; returnstring=false, name="df")
     main_io = IOBuffer()
     table_io = IOBuffer()
 
@@ -238,9 +238,12 @@ $name = \"\"\"
     if returnstring == true
       return s
     else
+      print(io, s)
       return nothing
     end
 end
+
+mwetable(t; kwargs...) = mwetable(stdout, t; kwargs...)
 
 function mwetable_helper(t::Symbol)
     t_name = QuoteNode(t)
@@ -308,7 +311,7 @@ function mwearray(; returnstring=false, name=nothing)
 end
 
 """
-    mwearray(t::AbstractMatrix; name=:X)
+    mwearray([io::IO=stdout], t::AbstractMatrix; name=:X)
 
 Create a Minimum Working Example (MWE) from
 a `Matrix`. `mwearray`
@@ -330,7 +333,7 @@ X = \"\"\"
 \"\"\" |> IOBuffer |> CSV.File |> Tables.matrix
 ```
 """
-function mwearray(t::AbstractMatrix; returnstring=false, name=:X)
+function mwearray(io::IO, t::AbstractMatrix; returnstring=false, name=:X)
     main_io = IOBuffer()
     array_io = IOBuffer()
 
@@ -350,12 +353,13 @@ $name = \"\"\"
     if returnstring == true
       return s
     else
+      print(io, s)
       return nothing
     end
 end
 
 """
-    mwearray(t::AbstractVector; name=:x)
+    mwearray([io::IO=stdout], t::AbstractVector; name=:x)
 
 Create a Minimum Working Example (MWE) from
 a `Vector`. `mwearray`
@@ -374,7 +378,7 @@ x = \"\"\"
 \"\"\" |> IOBuffer |> CSV.File |> Tables.matrix |> vec
 ```
 """
-function mwearray(t::AbstractVector; returnstring=false, name=:x)
+function mwearray(io::IO, t::AbstractVector; returnstring=false, name=:x)
     main_io = IOBuffer()
     array_io = IOBuffer()
 
@@ -396,9 +400,12 @@ $name = \"\"\"
     if returnstring == true
       return s
     else
+      print(io, s)
       return nothing
     end
 end
+
+mwearray(t::Union{AbstractVector, AbstractMatrix}; kwargs...) = mwearray(stdout, t; kwargs...)
 
 function mwearray_helper(t::Symbol)
     t_name = QuoteNode(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,8 +85,12 @@ a,b
 
     t = (a = [1, 3], b = [2, 4])
     s = mwetable(t; returnstring = true)
-
     @test s == s_correct
+
+    # Tests the default printing to stdout
+    io = IOBuffer()
+    mwetable(io, t; returnstring=false)
+    @test String(take!(io)) == s_correct
 end
 
 @testset "mwearray" begin
@@ -105,11 +109,14 @@ X = \"\"\"
 
     @test s == s_correct
 
-
     t = [1 2; 3 4]
     s = mwearray(t; returnstring = true)
 
     @test s == s_correct
+
+    io = IOBuffer()
+    mwearray(io, t; returnstring=false)
+    @test String(take!(io)) == s_correct
 
     """
     1
@@ -135,6 +142,11 @@ x = \"\"\"
 
     s = mwearray(x; returnstring=true)
     @test s == s_correct
+
+    # Tests the default printing to stdout
+    io = IOBuffer()
+    mwearray(io, x; returnstring=false)
+    @test String(take!(io)) == s_correct
 end
 
 @testset "@mwetable" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,7 +82,6 @@ a,b
 
     @test s == s_correct
 
-
     t = (a = [1, 3], b = [2, 4])
     s = mwetable(t; returnstring = true)
     @test s == s_correct
@@ -90,6 +89,11 @@ a,b
     # Tests the default printing to stdout
     io = IOBuffer()
     mwetable(io, t; returnstring=false)
+    @test String(take!(io)) == s_correct
+
+    io = IOBuffer()
+    cliptable(t)
+    mwetable(io; returnstring=false)
     @test String(take!(io)) == s_correct
 end
 
@@ -116,6 +120,11 @@ X = \"\"\"
 
     io = IOBuffer()
     mwearray(io, t; returnstring=false)
+    @test String(take!(io)) == s_correct
+
+    io = IOBuffer()
+    cliparray(t)
+    mwearray(io)
     @test String(take!(io)) == s_correct
 
     """
@@ -147,6 +156,12 @@ x = \"\"\"
     io = IOBuffer()
     mwearray(io, x; returnstring=false)
     @test String(take!(io)) == s_correct
+
+    io = IOBuffer()
+    cliparray(x)
+    mwearray(io)
+    @test String(take!(io)) == s_correct
+
 end
 
 @testset "@mwetable" begin


### PR DESCRIPTION
Fixes https://github.com/pdeffebach/ClipData.jl/issues/29

Changes:
- add default io=stdout for mwetable and mwearray
- add test case to check that the printing works when `returnstring=false` (=default)

FYI. I didn't add the default IO for the "reading" functionality `mwetable()`, because that seemed superfluous (it then passes everything to `mwetable(t)` anyway).

Tests pass. PR Should be ready for review.